### PR TITLE
Query cache

### DIFF
--- a/lib/master_slave_adapter.rb
+++ b/lib/master_slave_adapter.rb
@@ -229,6 +229,22 @@ module ActiveRecord
         connections.each { |c| c.reset! }
       end
 
+      def cache(&block)
+        connections.inject(block) do |block, connection|
+          lambda { connection.cache(&block) }
+        end.call
+      end
+
+      def uncached(&block)
+        connections.inject(block) do |block, connection|
+          lambda { connection.uncached(&block) }
+        end.call
+      end
+
+      def clear_query_cache
+        connections.each { |connection| connection.clear_query_cache }
+      end
+
       # Someone calling execute directly on the connection is likely to be a
       # write, respectively some DDL statement. People really shouldn't do that,
       # but let's delegate this to master, just to be sure.

--- a/lib/master_slave_adapter.rb
+++ b/lib/master_slave_adapter.rb
@@ -61,7 +61,7 @@ module ActiveRecord
       end
 
       def load_adapter(adapter_name)
-        unless self.respond_to?("#{adapter_name}_connection")
+        unless respond_to?("#{adapter_name}_connection")
           begin
             require 'rubygems'
             gem "activerecord-#{adapter_name}-adapter"
@@ -135,11 +135,11 @@ module ActiveRecord
       # MASTER SLAVE ADAPTER INTERFACE ========================================
 
       def with_master
-        with(self.master_connection, :master) { yield }
+        with(master_connection) { yield }
       end
 
       def with_slave
-        with(self.slave_connection!, :slave) { yield }
+        with(slave_connection!) { yield }
       end
 
       def with_consistency(clock)
@@ -148,12 +148,12 @@ module ActiveRecord
         slave = slave_connection!
         conn =
           if !open_transaction? && slave_consistent?(slave, clock)
-            [ slave, :slave ]
+            slave
           else
-            [ master_connection, :master ]
+            master_connection
           end
 
-        with(*conn) { yield }
+        with(conn) { yield }
 
         self.current_clock || clock
       end
@@ -208,25 +208,25 @@ module ActiveRecord
 
       def rollback_db_transaction
         on_commit_callbacks.clear
-        with(master_connection, :master) { |conn| conn.rollback_db_transaction }
+        with(master_connection) { |conn| conn.rollback_db_transaction }
         on_rollback_callbacks.shift.call until on_rollback_callbacks.blank?
       end
 
       def active?
         return true if @disable_connection_test
-        self.connections.map { |c| c.active? }.reduce(true) { |m,s| s ? m : s }
+        connections.map { |c| c.active? }.all?
       end
 
       def reconnect!
-        self.connections.each { |c| c.reconnect! }
+        connections.each { |c| c.reconnect! }
       end
 
       def disconnect!
-        self.connections.each { |c| c.disconnect! }
+        connections.each { |c| c.disconnect! }
       end
 
       def reset!
-        self.connections.each { |c| c.reset! }
+        connections.each { |c| c.reset! }
       end
 
       # Someone calling execute directly on the connection is likely to be a
@@ -282,13 +282,13 @@ module ActiveRecord
       # ok, we might have missed more
       def method_missing(name, *args, &blk)
         master_connection.send(name.to_sym, *args, &blk).tap do
-          warn %Q{
+          @logger.try(:warn, %Q{
             You called the unsupported method '#{name}' on #{self.class.name}.
             In order to help us improve master_slave_adapter, please report this
             to: https://github.com/soundcloud/master_slave_adapter/issues
 
             Thank you.
-          }
+          })
         end
       end
 
@@ -301,7 +301,7 @@ module ActiveRecord
                :to => :connection_for_read
 
       def connection_for_read
-        open_transaction? ? master_connection : self.current_connection
+        open_transaction? ? master_connection : current_connection
       end
       private :connection_for_read
 
@@ -366,7 +366,7 @@ module ActiveRecord
     protected
 
       def on_write
-        with(master_connection, :master) do |conn|
+        with(master_connection) do |conn|
           yield(conn).tap do
             unless open_transaction?
               if mc = master_clock
@@ -379,28 +379,12 @@ module ActiveRecord
         end
       end
 
-      def with(conn, name)
+      def with(conn)
         self.current_connection = conn
         yield(conn).tap { connection_stack.shift }
       end
 
     private
-
-      def logger
-        @logger # ||= Logger.new(STDOUT)
-      end
-
-      def info(msg)
-        logger.try(:info, msg)
-      end
-
-      def warn(msg)
-        logger.try(:warn, msg)
-      end
-
-      def debug(msg)
-        logger.debug(msg) if logger && logger.debug?
-      end
 
       def connect(cfg, name)
         adapter_method = "#{cfg.fetch(:adapter)}_connection".to_sym

--- a/specs/specs.rb
+++ b/specs/specs.rb
@@ -77,7 +77,7 @@ describe ActiveRecord::ConnectionAdapters::MasterSlaveAdapter do
     ActiveRecord::Base.connection_handler.clear_all_connections!
   end
 
-  describe 'with common configuration' do
+  describe 'common configuration' do
     before do
       [ master_connection, slave_connection ].each do |c|
         c.stub!( :select_value ).with( "SELECT 1", "test select" ).and_return( true )
@@ -160,7 +160,7 @@ describe ActiveRecord::ConnectionAdapters::MasterSlaveAdapter do
     end
   end
 
-  context "connection testing" do
+  describe "connection testing" do
     context "disabled" do
       let(:database_setup) do
         default_database_setup.merge(:disable_connection_test => 'true')
@@ -198,7 +198,7 @@ describe ActiveRecord::ConnectionAdapters::MasterSlaveAdapter do
     end
   end
 
-  describe 'with consistency' do
+  describe 'consistency' do
     before do
       ActiveRecord::ConnectionAdapters::MasterSlaveAdapter.reset!
 
@@ -287,7 +287,6 @@ describe ActiveRecord::ConnectionAdapters::MasterSlaveAdapter do
         new_clock.should be_a(zero.class)
         new_clock.should > old_clock
       end
-
     end
 
     it "should update the clock after a transaction" do
@@ -301,7 +300,7 @@ describe ActiveRecord::ConnectionAdapters::MasterSlaveAdapter do
       master_connection.
         should_receive('update').exactly(3).times.with('testing').
         and_return(true)
-     master_connection.
+      master_connection.
         should_receive('select_all').exactly(5).times.with('testing').
         and_return(true)
       %w(begin_db_transaction
@@ -512,7 +511,7 @@ describe ActiveRecord::ConnectionAdapters::MasterSlaveAdapter do
       end
     end
 
-    context "rollback" do
+    context "on rollback" do
       it "on_commit callback should not be called" do
         x = false
         adapter_connection.on_commit { x = true }
@@ -523,6 +522,43 @@ describe ActiveRecord::ConnectionAdapters::MasterSlaveAdapter do
         x = false
         adapter_connection.on_rollback { x = true }
         lambda { fail_tx }.should change { x }.to(true)
+      end
+    end
+  end
+
+  describe "query cache" do
+    describe "#cache" do
+      it "activities query caching on all connections" do
+        master_connection.should_receive(:cache).and_yield
+        slave_connection.should_receive(:cache).and_yield
+        master_connection.should_not_receive(:select_value)
+        slave_connection.should_receive(:select_value)
+
+        adapter_connection.cache do
+          adapter_connection.select_value("SELECT 42")
+        end
+      end
+    end
+
+    describe "#uncached" do
+      it "deactivates query caching on all connections" do
+        master_connection.should_receive(:uncached).and_yield
+        slave_connection.should_receive(:uncached).and_yield
+        master_connection.should_not_receive(:select_value)
+        slave_connection.should_receive(:select_value)
+
+        adapter_connection.uncached do
+          adapter_connection.select_value("SELECT 42")
+        end
+      end
+    end
+
+    describe "#clear_query_cache" do
+      it "clears the query cache on all connections" do
+        master_connection.should_receive(:clear_query_cache)
+        slave_connection.should_receive(:clear_query_cache)
+
+        adapter_connection.clear_query_cache
       end
     end
   end

--- a/specs/specs.rb
+++ b/specs/specs.rb
@@ -44,14 +44,14 @@ describe ActiveRecord::ConnectionAdapters::MasterSlaveAdapter do
       'master connection',
       mocked_methods.merge(:open_transactions => 0)
     ).tap do |conn|
-      conn.stub!(:uncached) { |blk| blk.call }
+      conn.stub!(:uncached).and_yield
       ActiveRecord::Base.master_mock = conn
     end
   end
 
   let!(:slave_connection) do
     mock('slave connection', mocked_methods).tap do |conn|
-      conn.stub!(:uncached) { |blk| blk.call }
+      conn.stub!(:uncached).and_yield
       ActiveRecord::Base.slave_mock = conn
     end
   end


### PR DESCRIPTION
Add support for Activerecords query cache. ActiveRecord currently calls `#cache` on the master slave adapter and sets an instance variable which activates the query caching. This change passes `#cache` and `#uncached calls to all connections, which means each of them manages its own cache.
